### PR TITLE
fix(ionic-react): fix generated e2e tests for Ionic

### DIFF
--- a/libs/ionic-react/src/schematics/application/schematic.ts
+++ b/libs/ionic-react/src/schematics/application/schematic.ts
@@ -161,7 +161,9 @@ function importCypressTestingLibraryCommands(options: NormalizedSchema) {
 
     const content = tree.read(fileName);
     let strContent = '';
-    if (content) strContent = content.toString();
+    if (content) {
+      strContent = content.toString();
+    }
 
     const appendIndex = strContent.indexOf("import './commands';");
     const contentToAppend = "import '@testing-library/cypress/add-commands';\n";
@@ -175,12 +177,56 @@ function importCypressTestingLibraryCommands(options: NormalizedSchema) {
   };
 }
 
+function configureAppPageObjectForIonic(options: NormalizedSchema) {
+  return (tree: Tree) => {
+    const fileName = `${options.e2eRoot}/src/support/app.po.${
+      options.js ? 'js' : 'ts'
+    }`;
+
+    const content = tree.read(fileName);
+    let strContent = '';
+    if (content) {
+      strContent = content.toString();
+    }
+    const updatedContent = strContent.replace(
+      "cy.get('h1')",
+      "cy.get('.container')"
+    );
+
+    tree.overwrite(fileName, updatedContent);
+    return tree;
+  };
+}
+
+function configureAppTestForIonic(options: NormalizedSchema) {
+  return (tree: Tree) => {
+    const fileName = `${options.e2eRoot}/src/integration/app.spec.${
+      options.js ? 'js' : 'ts'
+    }`;
+
+    const content = tree.read(fileName);
+    let strContent = '';
+    if (content) {
+      strContent = content.toString();
+    }
+    const updatedContent = strContent.replace(
+      `Welcome to ${options.projectName}!`,
+      'Start with Ionic'
+    );
+
+    tree.overwrite(fileName, updatedContent);
+    return tree;
+  };
+}
+
 function configureCypressForIonic(options: NormalizedSchema): Rule {
   if (options.e2eTestRunner === 'cypress') {
     return chain([
       addCypressDependencies(),
       addCypressTestingLibraryTsconfigType(options),
-      importCypressTestingLibraryCommands(options)
+      importCypressTestingLibraryCommands(options),
+      configureAppPageObjectForIonic(options),
+      configureAppTestForIonic(options)
     ]);
   } else {
     return noop();


### PR DESCRIPTION
# Description

The e2e tests generated by `@nrwl/cypress` do not work with the Ionic blank starter, so this updates the related files to be relevant.

# PR Checklist

- [x] `yarn affected:build` does not throw any warnings or errors
- [x] `yarn affected:lint` does not throw any warnings or errors
- [ ] Unit tests have been added or updated
- [x] `yarn affected:test` does not throw any warnings or errors
- [x] e2e tests have been added or updated
- [x] `yarn affected:e2e` does not throw any warnings or errors

# Issue

Resolves #53 
