### PR TITLE
feat(ionic-react): import Jest DOM Testing Library for unit tests

### DIFF
--- a/apps/ionic-react-e2e/tests/application.test.ts
+++ b/apps/ionic-react-e2e/tests/application.test.ts
@@ -1,6 +1,7 @@
 import {
   checkFilesExist,
   ensureNxProject,
+  readFile,
   readJson,
   runNxCommandAsync,
   uniq
@@ -50,6 +51,9 @@ describe('application e2e', () => {
       checkFilesExist(`apps/${plugin}/src/index.html`);
       checkFilesExist(`apps/${plugin}/src/manifest.json`);
     }).not.toThrow();
+
+    const jestConfig = readFile(`apps/${plugin}/jest.config.js`);
+    expect(jestConfig).toContain('setup-tests.ts');
   }
 
   it('should generate application', async done => {
@@ -100,15 +104,20 @@ describe('application e2e', () => {
     expect(result.stdout).toContain('Built at');
 
     expect(() => {
+      checkFilesExist(`apps/${plugin}/setupTests.ts`);
+
+      checkFilesExist(`apps/${plugin}/src/app/App.tsx`);
+      checkFilesExist(`apps/${plugin}/src/app/App.spec.tsx`);
+
       checkFilesExist(`apps/${plugin}/src/app/components/ExploreContainer.tsx`);
       checkFilesExist(`apps/${plugin}/src/app/components/ExploreContainer.css`);
 
       checkFilesExist(`apps/${plugin}/src/app/pages/Home.tsx`);
       checkFilesExist(`apps/${plugin}/src/app/pages/Home.css`);
-
-      checkFilesExist(`apps/${plugin}/src/app/App.tsx`);
-      checkFilesExist(`apps/${plugin}/src/app/App.spec.tsx`);
     }).not.toThrow();
+
+    const jestConfig = readFile(`apps/${plugin}/jest.config.js`);
+    expect(jestConfig).toContain('setupTests.ts');
 
     done();
   }, 120000);

--- a/libs/ionic-react/migrations.json
+++ b/libs/ionic-react/migrations.json
@@ -4,6 +4,11 @@
       "version": "0.1.1-beta.1",
       "description": "Add Nrwl React library",
       "factory": "./src/migrations/update-0-1-1/update-0-1-1"
+    },
+    "update-1.1.0": {
+      "version": "1.1.0-beta.1",
+      "description": "Import @testing-library/jest-dom commands for unit tests",
+      "factory": "./src/migrations/update-1-1-0/update-1-1-0"
     }
   }
 }

--- a/libs/ionic-react/src/migrations/update-1-1-0/files/jest/setup-tests.ts.template
+++ b/libs/ionic-react/src/migrations/update-1-1-0/files/jest/setup-tests.ts.template
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom/extend-expect';

--- a/libs/ionic-react/src/migrations/update-1-1-0/test-files/setup-tests.ts
+++ b/libs/ionic-react/src/migrations/update-1-1-0/test-files/setup-tests.ts
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom/extend-expect';

--- a/libs/ionic-react/src/migrations/update-1-1-0/update-1-1-0.spec.ts
+++ b/libs/ionic-react/src/migrations/update-1-1-0/update-1-1-0.spec.ts
@@ -1,0 +1,161 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { serializeJson } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import * as path from 'path';
+import { readFileSync } from 'fs';
+
+describe('Update 1-1-0', () => {
+  let initialTree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(async () => {
+    initialTree = Tree.empty();
+    initialTree = createEmptyWorkspace(initialTree);
+    schematicRunner = new SchematicTestRunner(
+      '@nxtend/ionic-react',
+      path.join(__dirname, '../../../migrations.json')
+    );
+
+    initialTree.overwrite(
+      'package.json',
+      serializeJson({ devDependencies: { '@nrwl/jest': '9.0.0' } })
+    );
+
+    initialTree.overwrite(
+      'workspace.json',
+      serializeJson({
+        projects: {
+          'project-one': {
+            root: 'apps/project-one',
+            architect: {
+              test: {
+                options: {
+                  jestConfig: 'apps/project-one/jest.config.js',
+                  webpackConfig: '@nxtend/ionic-react/plugins/webpack'
+                }
+              }
+            }
+          },
+          'project-two': {
+            root: 'apps/project-two',
+            architect: {
+              test: {
+                options: {
+                  jestConfig: 'apps/project-two/jest.config.js',
+                  webpackConfig: '@nxtend/ionic-react/plugins/webpack'
+                }
+              }
+            }
+          },
+          'project-three': {
+            root: 'apps/project-three',
+            architect: {
+              test: {
+                options: {
+                  jestConfig: 'apps/project-three/jest.config.js',
+                  webpackConfig: '@nxtend/ionic-react/plugins/webpack'
+                }
+              }
+            }
+          }
+        }
+      })
+    );
+
+    initialTree.create(
+      'apps/project-one/jest.config.js',
+      `module.exports = {
+        name: 'project-one',
+        preset: '../../jest.config.js',
+        transform: {
+          '^.+\\.[tj]sx?$': 'ts-jest'
+        },
+        moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+        coverageDirectory: '../../coverage/apps/project-one',
+        moduleNameMapper: {
+          '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+            '<rootDir>/src/app/__mocks__/fileMock.js'
+        },
+        modulePathIgnorePatterns: ['<rootDir>/.*/__mocks__']
+      };`
+    );
+
+    initialTree.create(
+      'apps/project-two/jest.config.js',
+      `module.exports = {
+        name: 'project-two',
+        preset: '../../jest.config.js',
+        transform: {
+          '^.+\\.[tj]sx?$': 'ts-jest'
+        },
+        moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+        coverageDirectory: '../../coverage/apps/project-two',
+        moduleNameMapper: {
+          '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+            '<rootDir>/src/app/__mocks__/fileMock.js'
+        },
+        modulePathIgnorePatterns: ['<rootDir>/.*/__mocks__'],
+        setupFilesAfterEnv: ['<rootDir>/configure-tests.js']
+      };`
+    );
+
+    initialTree.create(
+      'apps/project-three/jest.config.js',
+      `module.exports = {
+        name: 'project-three',
+        preset: '../../jest.config.js',
+        transform: {
+          '^.+\\.[tj]sx?$': 'ts-jest'
+        },
+        moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+        coverageDirectory: '../../coverage/apps/project-three',
+        moduleNameMapper: {
+          '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+            '<rootDir>/src/app/__mocks__/fileMock.js'
+        },
+        modulePathIgnorePatterns: ['<rootDir>/.*/__mocks__'],
+        setupFilesAfterEnv: ['<rootDir>/setup-tests.ts']
+      };`
+    );
+
+    initialTree.create(
+      'apps/project-three/setup-tests.ts',
+      readFileSync(
+        path.join(__dirname, './test-files/setup-tests.ts').toString()
+      )
+    );
+  });
+
+  it(`should add and configure Jest setup file`, async () => {
+    // eslint-disable-next-line require-atomic-updates
+    const result = await schematicRunner
+      .runSchematicAsync('update-1.1.0', {}, initialTree)
+      .toPromise();
+
+    const updateJestProjectOne = result.readContent(
+      'apps/project-one/jest.config.js'
+    );
+    const updateJestProjectTwo = result.readContent(
+      'apps/project-two/jest.config.js'
+    );
+    const updateJestProjectThree = result.readContent(
+      'apps/project-three/jest.config.js'
+    );
+
+    expect(updateJestProjectOne).toContain(
+      "setupFilesAfterEnv: ['<rootDir>/setup-tests.ts']"
+    );
+    expect(result.exists('apps/project-one/setup-tests.ts'));
+
+    expect(updateJestProjectTwo).toContain(
+      "setupFilesAfterEnv: [\n    '<rootDir>/setup-tests.ts',\n    '<rootDir>/configure-tests.js'\n  ]"
+    );
+    expect(result.exists('apps/project-two/setup-tests.ts'));
+
+    expect(updateJestProjectThree).toContain(
+      "setupFilesAfterEnv: ['<rootDir>/setup-tests.ts']"
+    );
+    expect(result.exists('apps/project-three/setup-tests.ts'));
+  });
+});

--- a/libs/ionic-react/src/migrations/update-1-1-0/update-1-1-0.ts
+++ b/libs/ionic-react/src/migrations/update-1-1-0/update-1-1-0.ts
@@ -1,0 +1,199 @@
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+import {
+  apply,
+  applyTemplates,
+  chain,
+  mergeWith,
+  move,
+  Rule,
+  SchematicContext,
+  Tree,
+  url
+} from '@angular-devkit/schematics';
+import {
+  formatFiles,
+  insert,
+  offsetFromRoot,
+  readJsonInTree,
+  readWorkspace
+} from '@nrwl/workspace';
+import {
+  Change,
+  getSourceNodes,
+  InsertChange
+} from '@nrwl/workspace/src/utils/ast-utils';
+import * as ts from 'typescript';
+
+function displayInformation(host: Tree, context: SchematicContext) {
+  const config = readJsonInTree(host, 'package.json');
+  if (config.devDependencies && config.devDependencies['@nrwl/jest']) {
+    context.logger.info(stripIndents`
+    \`@testing-library/jest-dom\` commands are being imported for unit tests.
+    
+    We are updating \`jest.config.js\` in each Ionic React project to include setupFilesAfterEnv.
+    This is being added as a TypeScript file. If you would rather exclusively use JavaScript files,
+    you can change this to a \`.js\` file.
+    
+    See: https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array
+  `);
+  }
+}
+
+function getJestConfigsToUpdate(host: Tree): Map<string, string> {
+  const workspaceConfig = readWorkspace(host);
+  const jestConfigsToUpdate = new Map();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Object.values<any>(workspaceConfig.projects).forEach(project => {
+    if (!project.architect) {
+      return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Object.values<any>(project.architect).forEach(target => {
+      if (
+        target.options.webpackConfig !== '@nxtend/ionic-react/plugins/webpack'
+      ) {
+        return;
+      }
+
+      if (target.options.jestConfig) {
+        jestConfigsToUpdate.set(target.options.jestConfig, project.root);
+      }
+
+      if (target.configurations) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        Object.values<any>(target.configurations).forEach(config => {
+          if (config.jestConfig) {
+            jestConfigsToUpdate.set(config.jestConfig, project.root);
+          }
+        });
+      }
+    });
+  });
+
+  return jestConfigsToUpdate;
+}
+
+function addSetupFilesJestConfig(
+  host: Tree,
+  configPath: string,
+  contents: string
+) {
+  const sourceFile = ts.createSourceFile(
+    configPath,
+    contents,
+    ts.ScriptTarget.Latest
+  );
+
+  const changes: Change[] = [];
+  const sourceNodes = getSourceNodes(sourceFile);
+  const lastNode = sourceNodes[sourceNodes.length - 3];
+  changes.push(
+    new InsertChange(
+      configPath,
+      lastNode.getFullStart(),
+      `,\nsetupFilesAfterEnv: ['<rootDir>/setup-tests.ts']\r`
+    )
+  );
+
+  insert(
+    host,
+    configPath,
+    changes.sort((a, b) => (a.order > b.order ? -1 : 1))
+  );
+}
+
+function updateSetupFilesJestConfig(
+  host: Tree,
+  configPath: string,
+  contents: string
+) {
+  const sourceFile = ts.createSourceFile(
+    configPath,
+    contents,
+    ts.ScriptTarget.Latest
+  );
+
+  const changes: Change[] = [];
+  const sourceNodes = getSourceNodes(sourceFile);
+
+  sourceNodes.forEach((node, index) => {
+    if (
+      ts.isPropertyAssignment(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === 'setupFilesAfterEnv'
+    ) {
+      const setupFilePaths: string[] = [];
+      const valueNode = sourceNodes[index + 3];
+
+      if (valueNode && ts.isArrayLiteralExpression(valueNode)) {
+        valueNode.elements.forEach(element => {
+          if (element && ts.isStringLiteral(element)) {
+            setupFilePaths.push(element.text);
+          }
+        });
+
+        if (!setupFilePaths.includes('<rootDir>/setup-tests.ts')) {
+          changes.push(
+            new InsertChange(
+              configPath,
+              valueNode.getStart(sourceFile) + 1,
+              "'<rootDir>/setup-tests.ts', "
+            )
+          );
+
+          insert(
+            host,
+            configPath,
+            changes.sort((a, b) => (a.order > b.order ? -1 : 1))
+          );
+        }
+      }
+    }
+  });
+}
+
+function updateJestConfig(host: Tree, configPath: string) {
+  const contents = host.read(configPath).toString();
+
+  if (!contents.includes('setupFilesAfterEnv')) {
+    addSetupFilesJestConfig(host, configPath, contents);
+  } else {
+    updateSetupFilesJestConfig(host, configPath, contents);
+  }
+}
+
+function addFiles(projectRoot: string) {
+  mergeWith(
+    apply(url(`./files/jest`), [
+      applyTemplates({
+        offsetFromRoot: offsetFromRoot(projectRoot)
+      }),
+      move(projectRoot)
+    ])
+  );
+}
+
+function importJestDomTestingLibraryCommands(host: Tree) {
+  const config = readJsonInTree(host, 'package.json');
+
+  if (config.devDependencies && config.devDependencies['@nrwl/jest']) {
+    const jestConfigsToUpdate = getJestConfigsToUpdate(host);
+
+    jestConfigsToUpdate.forEach((projectRoot, configPath) => {
+      if (host.exists(configPath)) {
+        updateJestConfig(host, configPath);
+        addFiles(projectRoot);
+      }
+    });
+  }
+}
+
+export default function update(): Rule {
+  return chain([
+    displayInformation,
+    importJestDomTestingLibraryCommands,
+    formatFiles()
+  ]);
+}

--- a/libs/ionic-react/src/schematics/application/files/jest/__setupTestsFileName__.ts.template
+++ b/libs/ionic-react/src/schematics/application/files/jest/__setupTestsFileName__.ts.template
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom/extend-expect';

--- a/libs/ionic-react/src/schematics/application/files/jest/jest.config.js.template
+++ b/libs/ionic-react/src/schematics/application/files/jest/jest.config.js.template
@@ -15,5 +15,6 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/src/app/__mocks__/fileMock.js'
   },
-  modulePathIgnorePatterns: ['<rootDir>/.*/__mocks__']
+  modulePathIgnorePatterns: ['<rootDir>/.*/__mocks__'],
+  setupFilesAfterEnv: ['<rootDir>/<%= setupTestsFileName %>.<% if (js) { %>js<% } else { %>ts<% } %>']
 };

--- a/libs/ionic-react/src/schematics/application/schematic.spec.ts
+++ b/libs/ionic-react/src/schematics/application/schematic.spec.ts
@@ -62,6 +62,8 @@ describe('application', () => {
     expect(tree.exists(`${projectRoot}/src/index.html`)).toBeTruthy();
     expect(tree.exists(`${projectRoot}/src/manifest.json`)).toBeTruthy();
 
+    expect(tree.exists(`${projectRoot}/setup-tests.ts`)).toBeTruthy();
+
     expect(
       tree.exists(`${projectRoot}/src/app/${options.name}.spec.tsx`)
     ).toBeFalsy();
@@ -76,6 +78,9 @@ describe('application', () => {
       .toPromise();
 
     testGeneratedFiles(tree);
+    expect(tree.readContent(`${projectRoot}/jest.config.js`)).toContain(
+      'setup-tests.ts'
+    );
   });
 
   it('should generate application with app alias', async () => {
@@ -154,6 +159,8 @@ describe('application', () => {
 
     expect(tree.exists(`${projectRoot}/src/app/app.tsx`)).toBeFalsy();
     expect(tree.exists(`${projectRoot}/src/main.tsx`)).toBeFalsy();
+
+    expect(tree.exists(`${projectRoot}/setup-tests.js`)).toBeTruthy();
   });
 
   it('should generate pascal case file names', async () => {
@@ -165,6 +172,14 @@ describe('application', () => {
       )
       .toPromise();
 
+    expect(tree.exists(`${projectRoot}/setupTests.ts`)).toBeTruthy();
+    expect(tree.readContent(`${projectRoot}/jest.config.js`)).toContain(
+      'setupTests.ts'
+    );
+
+    expect(tree.exists(`${projectRoot}/src/app/App.tsx`)).toBeTruthy();
+    expect(tree.exists(`${projectRoot}/src/app/App.spec.tsx`)).toBeTruthy();
+
     expect(
       tree.exists(`${projectRoot}/src/app/components/ExploreContainer.tsx`)
     ).toBeTruthy();
@@ -174,9 +189,6 @@ describe('application', () => {
 
     expect(tree.exists(`${projectRoot}/src/app/pages/Home.tsx`)).toBeTruthy();
     expect(tree.exists(`${projectRoot}/src/app/pages/Home.css`)).toBeTruthy();
-
-    expect(tree.exists(`${projectRoot}/src/app/App.spec.tsx`)).toBeTruthy();
-    expect(tree.exists(`${projectRoot}/src/app/App.tsx`)).toBeTruthy();
   });
 
   describe('--style', () => {

--- a/libs/ionic-react/src/schematics/application/schematic.ts
+++ b/libs/ionic-react/src/schematics/application/schematic.ts
@@ -41,6 +41,7 @@ interface NormalizedSchema extends ApplicationSchematicSchema {
   appFileName: string;
   homeFileName: string;
   exploreContainerFileName: string;
+  setupTestsFileName: string;
   styledModule: null | string;
 }
 
@@ -65,6 +66,9 @@ function normalizeOptions(
   const exploreContainerFileName = options.pascalCaseFiles
     ? 'ExploreContainer'
     : 'explore-container';
+  const setupTestsFileName = options.pascalCaseFiles
+    ? 'setupTests'
+    : 'setup-tests';
 
   const styledModule = /^(css|scss|less|styl)$/.test(options.style)
     ? null
@@ -81,6 +85,7 @@ function normalizeOptions(
     appFileName,
     homeFileName,
     exploreContainerFileName,
+    setupTestsFileName,
     styledModule
   };
 }
@@ -128,7 +133,8 @@ function addJestMocks(options: NormalizedSchema): Rule {
           ...names(options.name),
           offsetFromRoot: offsetFromRoot(options.projectRoot)
         }),
-        move(options.projectRoot)
+        move(options.projectRoot),
+        options.js ? toJS() : noop()
       ]),
       MergeStrategy.Overwrite
     );


### PR DESCRIPTION
# Description

Import `@testing-library/jest-dom` commands into a Jest setup file to allow for assertions like `expect(element).toHaveTextContent(/react/i)`. This change also includes a migration to add this change to an existing `@nxtend/ionic-react` application.

# PR Checklist

- [x] `yarn affected:build` does not throw any warnings or errors
- [x] `yarn affected:lint` does not throw any warnings or errors
- [x] Unit tests have been added or updated
- [x] `yarn affected:test` does not throw any warnings or errors
- [x] e2e tests have been added or updated
- [x] `yarn affected:e2e` does not throw any warnings or errors

# Issue

Resolves #67 
