### PR TITLE
Ionicons 5.0.1

### DIFF
--- a/libs/ionic-react/migrations.json
+++ b/libs/ionic-react/migrations.json
@@ -7,7 +7,7 @@
     },
     "update-1.0.1": {
       "version": "1.0.1-beta.1",
-      "description": "Upgrade Ionic to 5.0.5",
+      "description": "Upgrade Ionic to 5.0.5 and ionicons to 5.0.1",
       "factory": "./src/migrations/update-1-0-1/update-1-0-1"
     }
   },
@@ -21,6 +21,10 @@
         },
         "@ionic/react-router": {
           "version": "5.0.5",
+          "alwaysAddToPackageJson": false
+        },
+        "ionicons": {
+          "version": "5.0.1",
           "alwaysAddToPackageJson": false
         }
       }

--- a/libs/ionic-react/src/migrations/update-1-0-1/update-1-0-1.spec.ts
+++ b/libs/ionic-react/src/migrations/update-1-0-1/update-1-0-1.spec.ts
@@ -19,9 +19,10 @@ describe('Update 1.0.1', () => {
     initialTree.overwrite(
       'package.json',
       serializeJson({
-        devDependencies: {
+        dependencies: {
           '@ionic/react': '5.0.4',
-          '@ionic/react-router': '5.0.4'
+          '@ionic/react-router': '5.0.4',
+          ionicons: '5.0.0'
         }
       })
     );
@@ -33,8 +34,9 @@ describe('Update 1.0.1', () => {
       .runSchematicAsync('update-1.0.1', {}, initialTree)
       .toPromise();
 
-    const { devDependencies } = readJsonInTree(result, '/package.json');
-    expect(devDependencies['@ionic/react']).toEqual('5.0.5');
-    expect(devDependencies['@ionic/react-router']).toEqual('5.0.5');
+    const { dependencies } = readJsonInTree(result, '/package.json');
+    expect(dependencies['@ionic/react']).toEqual('5.0.5');
+    expect(dependencies['@ionic/react-router']).toEqual('5.0.5');
+    expect(dependencies['ionicons']).toEqual('5.0.1');
   });
 });

--- a/libs/ionic-react/src/utils/versions.ts
+++ b/libs/ionic-react/src/utils/versions.ts
@@ -1,9 +1,9 @@
 export const nxtendVersion = '*';
 
-export const ionicReactVersion = '^5.0.5';
-export const ionicReactRouterVersion = '^5.0.5';
-export const ioniconsVersion = '^5.0.0';
+export const ionicReactVersion = '5.0.5';
+export const ionicReactRouterVersion = '5.0.5';
+export const ioniconsVersion = '5.0.0';
 
-export const testingLibraryJestDomVersion = '^4.2.4';
-export const testingLibraryUserEventVersion = '^8.1.3';
-export const testingLibraryCypressVersion = '^5.3.0';
+export const testingLibraryJestDomVersion = '4.2.4';
+export const testingLibraryUserEventVersion = '8.1.3';
+export const testingLibraryCypressVersion = '5.3.0';

--- a/libs/ionic-react/src/utils/versions.ts
+++ b/libs/ionic-react/src/utils/versions.ts
@@ -2,7 +2,7 @@ export const nxtendVersion = '*';
 
 export const ionicReactVersion = '5.0.5';
 export const ionicReactRouterVersion = '5.0.5';
-export const ioniconsVersion = '5.0.0';
+export const ioniconsVersion = '5.0.1';
 
 export const testingLibraryJestDomVersion = '4.2.4';
 export const testingLibraryUserEventVersion = '8.1.3';


### PR DESCRIPTION
# Description

Upgrade ionicons to 5.0.1.

# PR Checklist

- [x] `yarn affected:build` does not throw any warnings or errors
- [x] `yarn affected:lint` does not throw any warnings or errors
- [x] Unit tests have been added or updated
- [x] `yarn affected:test` does not throw any warnings or errors
- [ ] e2e tests have been added or updated
- [ ] `yarn affected:e2e` does not throw any warnings or errors

# Issue

Resolves #75 
