### PR TITLE
feat(ionic-react): [WIP] extend @nrwl/react schematics

### DIFF
--- a/libs/ionic-react/CHANGELOG.md
+++ b/libs/ionic-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 1.1.0
+
+## Features
+
+- extend `@nrwl/react` schematics
+
 # 1.0.2
 
 ## Bug Fixes

--- a/libs/ionic-react/README.md
+++ b/libs/ionic-react/README.md
@@ -56,6 +56,10 @@ Options:
   --help                  Show available options for project target.
 ```
 
+### @nrwl/react
+
+This extends the official `@nrwl/react` plugin, so all of those [schematics](https://nx.dev/react/plugins_react/overview#schematics) are available as a fallback.
+
 ## Maintainers
 
 [@devinshoemaker](https://github.com/devinshoemaker)

--- a/libs/ionic-react/collection.json
+++ b/libs/ionic-react/collection.json
@@ -2,6 +2,7 @@
   "$schema": "../../node_modules/@angular-devkit/schematics/collection-schema.json",
   "name": "ionic-react",
   "version": "0.0.1",
+  "extends": ["@nrwl/react"],
   "schematics": {
     "init": {
       "factory": "./src/schematics/init/schematic",


### PR DESCRIPTION
# Description

All schematics from `@nrwl/react` are now available from `@nxtend/ionic-react` unless one is overridden like `application`.

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated
- [ ] e2e tests have been added or updated
- [x] Changelog has been updated if necessary
- [ ] `yarn affected:build` does not throw any warnings or errors
- [ ] `yarn affected:lint` does not throw any warnings or errors
- [ ] `yarn affected:test` does not throw any warnings or errors
- [ ] `yarn affected:e2e` does not throw any warnings or errors

# Issue

Resolves #99 
