### PR TITLE
cleanup(ionic-react): break application schematic into separate files

### DIFF
--- a/libs/ionic-react/src/schematics/application/lib/cypress.ts
+++ b/libs/ionic-react/src/schematics/application/lib/cypress.ts
@@ -1,0 +1,100 @@
+import { chain, noop, Rule, Tree } from '@angular-devkit/schematics';
+import { addDepsToPackageJson, updateJsonInTree } from '@nrwl/workspace';
+import { testingLibraryCypressVersion } from '../../../utils/versions';
+import { NormalizedSchema } from '../schematic';
+
+export function addDependencies(): Rule {
+  return addDepsToPackageJson(
+    {},
+    {
+      '@testing-library/cypress': testingLibraryCypressVersion
+    }
+  );
+}
+
+export function configureTestingLibraryTypes(options: NormalizedSchema) {
+  return updateJsonInTree(options.e2eRoot + '/tsconfig.json', json => {
+    json.compilerOptions.types.push('@types/testing-library__cypress');
+    return json;
+  });
+}
+
+export function importTestingLibraryCommands(options: NormalizedSchema) {
+  return (tree: Tree) => {
+    const fileName = `${options.e2eRoot}/src/support/index.${
+      options.js ? 'js' : 'ts'
+    }`;
+
+    const content = tree.read(fileName);
+    let strContent = '';
+    if (content) {
+      strContent = content.toString();
+    }
+
+    const appendIndex = strContent.indexOf("import './commands';");
+    const contentToAppend = "import '@testing-library/cypress/add-commands';\n";
+    const updatedContent =
+      strContent.slice(0, appendIndex) +
+      contentToAppend +
+      strContent.slice(appendIndex);
+
+    tree.overwrite(fileName, updatedContent);
+    return tree;
+  };
+}
+
+export function configureAppPageObjectForIonic(options: NormalizedSchema) {
+  return (tree: Tree) => {
+    const fileName = `${options.e2eRoot}/src/support/app.po.${
+      options.js ? 'js' : 'ts'
+    }`;
+
+    const content = tree.read(fileName);
+    let strContent = '';
+    if (content) {
+      strContent = content.toString();
+    }
+    const updatedContent = strContent.replace(
+      "cy.get('h1')",
+      "cy.get('.container')"
+    );
+
+    tree.overwrite(fileName, updatedContent);
+    return tree;
+  };
+}
+
+export function configureAppTestForIonic(options: NormalizedSchema) {
+  return (tree: Tree) => {
+    const fileName = `${options.e2eRoot}/src/integration/app.spec.${
+      options.js ? 'js' : 'ts'
+    }`;
+
+    const content = tree.read(fileName);
+    let strContent = '';
+    if (content) {
+      strContent = content.toString();
+    }
+    const updatedContent = strContent.replace(
+      `Welcome to ${options.projectName}!`,
+      'Start with Ionic'
+    );
+
+    tree.overwrite(fileName, updatedContent);
+    return tree;
+  };
+}
+
+export function configureCypressForIonic(options: NormalizedSchema): Rule {
+  if (options.e2eTestRunner === 'cypress') {
+    return chain([
+      addDependencies(),
+      configureTestingLibraryTypes(options),
+      importTestingLibraryCommands(options),
+      configureAppPageObjectForIonic(options),
+      configureAppTestForIonic(options)
+    ]);
+  } else {
+    return noop();
+  }
+}

--- a/libs/ionic-react/src/schematics/application/lib/files.ts
+++ b/libs/ionic-react/src/schematics/application/lib/files.ts
@@ -1,0 +1,47 @@
+import {
+  apply,
+  applyTemplates,
+  filter,
+  MergeStrategy,
+  mergeWith,
+  move,
+  noop,
+  Rule,
+  Tree,
+  url
+} from '@angular-devkit/schematics';
+import { names, offsetFromRoot } from '@nrwl/workspace';
+import { toJS } from '@nrwl/workspace/src/utils/rules/to-js';
+import { NormalizedSchema } from '../schematic';
+
+export function addIonicFiles(options: NormalizedSchema): Rule {
+  return mergeWith(
+    apply(url(`./files/blank`), [
+      applyTemplates({
+        ...options,
+        ...names(options.name),
+        offsetFromRoot: offsetFromRoot(options.projectRoot)
+      }),
+      options.styledModule
+        ? filter(file => !file.endsWith(`.${options.style}`))
+        : noop(),
+      move(options.projectRoot),
+      options.js ? toJS() : noop()
+    ]),
+    MergeStrategy.Overwrite
+  );
+}
+
+export function deleteUnusedFiles(options: NormalizedSchema): Rule {
+  return (tree: Tree) => {
+    tree.delete(options.projectRoot + '/src/favicon.ico');
+
+    if (!options.styledModule) {
+      tree.delete(
+        options.projectRoot + `/src/app/${options.appFileName}.` + options.style
+      );
+    }
+
+    return tree;
+  };
+}

--- a/libs/ionic-react/src/schematics/application/lib/jest.ts
+++ b/libs/ionic-react/src/schematics/application/lib/jest.ts
@@ -1,0 +1,91 @@
+import {
+  apply,
+  applyTemplates,
+  chain,
+  externalSchematic,
+  MergeStrategy,
+  mergeWith,
+  move,
+  noop,
+  Rule,
+  Tree,
+  url
+} from '@angular-devkit/schematics';
+import { names, offsetFromRoot } from '@nrwl/workspace';
+import { Change } from '@nrwl/workspace/src/core/file-utils';
+import {
+  getSourceNodes,
+  insert,
+  InsertChange,
+  readWorkspace
+} from '@nrwl/workspace/src/utils/ast-utils';
+import * as ts from 'typescript';
+import { NormalizedSchema } from '../schematic';
+
+export function executeJestProjectSchematic(options: NormalizedSchema): Rule {
+  return externalSchematic('@nrwl/jest', 'jest-project', {
+    project: options.projectName,
+    supportTsx: true,
+    skipSerializers: true,
+    setupFile: 'web-components'
+  });
+}
+
+export function configureMocks(options: NormalizedSchema) {
+  return (host: Tree) => {
+    const workspaceConfig = readWorkspace(host);
+    const configPath =
+      workspaceConfig.projects[options.projectName].architect.test.options
+        .jestConfig;
+    const contents = host.read(configPath).toString();
+
+    const sourceFile = ts.createSourceFile(
+      configPath,
+      contents,
+      ts.ScriptTarget.Latest
+    );
+
+    const changes: Change[] = [];
+    const sourceNodes = getSourceNodes(sourceFile);
+    const lastNode = sourceNodes[sourceNodes.length - 3];
+    changes.push(
+      new InsertChange(
+        configPath,
+        lastNode.getFullStart(),
+        `,\nmoduleNameMapper: {
+          '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+            '<rootDir>/src/app/__mocks__/fileMock.js'
+        },
+        modulePathIgnorePatterns: ['<rootDir>/.*/__mocks__']\r`
+      )
+    );
+
+    insert(host, configPath, changes);
+  };
+}
+
+export function addJestFiles(options: NormalizedSchema): Rule {
+  return mergeWith(
+    apply(url(`./files/jest`), [
+      applyTemplates({
+        ...options,
+        ...names(options.name),
+        offsetFromRoot: offsetFromRoot(options.projectRoot)
+      }),
+      move(options.projectRoot)
+    ]),
+    MergeStrategy.Overwrite
+  );
+}
+
+export function configureJestForIonic(options: NormalizedSchema): Rule {
+  if (options.unitTestRunner === 'jest') {
+    return chain([
+      executeJestProjectSchematic(options),
+      configureMocks(options),
+      addJestFiles(options)
+    ]);
+  } else {
+    return noop();
+  }
+}

--- a/libs/ionic-react/src/schematics/application/lib/update-workspace.ts
+++ b/libs/ionic-react/src/schematics/application/lib/update-workspace.ts
@@ -1,0 +1,36 @@
+import { chain, Rule } from '@angular-devkit/schematics';
+import { updateWorkspaceInTree } from '@nrwl/workspace';
+import { NormalizedSchema } from '../schematic';
+
+export function updateWorkspaceAssets(options: NormalizedSchema): Rule {
+  return updateWorkspaceInTree(json => {
+    const architect = json.projects[options.projectName].architect;
+
+    const assets: string[] = architect.build.options.assets.filter(
+      (asset: string) => asset != options.projectRoot + '/src/favicon.ico'
+    );
+    assets.push(options.projectRoot + '/src/manifest.json');
+
+    architect.build.options.assets = assets;
+    json.projects[options.projectName].architect = architect;
+
+    return json;
+  });
+}
+
+export function updateWebpackConfig(options: NormalizedSchema): Rule {
+  return updateWorkspaceInTree(json => {
+    const architect = json.projects[options.projectName].architect;
+
+    architect.build.options.webpackConfig =
+      '@nxtend/ionic-react/plugins/webpack';
+
+    json.projects[options.projectName].architect = architect;
+
+    return json;
+  });
+}
+
+export function updateWorkspaceForIonic(options: NormalizedSchema): Rule {
+  return chain([updateWorkspaceAssets(options), updateWebpackConfig(options)]);
+}

--- a/libs/ionic-react/src/schematics/application/schematic.ts
+++ b/libs/ionic-react/src/schematics/application/schematic.ts
@@ -1,47 +1,22 @@
-import {
-  apply,
-  applyTemplates,
-  chain,
-  externalSchematic,
-  filter,
-  MergeStrategy,
-  mergeWith,
-  move,
-  noop,
-  Rule,
-  Tree,
-  url
-} from '@angular-devkit/schematics';
+import { chain, externalSchematic, Rule } from '@angular-devkit/schematics';
 import {
   addDepsToPackageJson,
   formatFiles,
-  names,
-  offsetFromRoot,
   projectRootDir,
   ProjectType,
-  toFileName,
-  updateJsonInTree,
-  updateWorkspaceInTree
+  toFileName
 } from '@nrwl/workspace';
-import { Change } from '@nrwl/workspace/src/core/file-utils';
-import {
-  getSourceNodes,
-  insert,
-  InsertChange,
-  readWorkspace
-} from '@nrwl/workspace/src/utils/ast-utils';
-import { toJS } from '@nrwl/workspace/src/utils/rules/to-js';
-import * as ts from 'typescript';
-import {
-  ionicReactRouterVersion,
-  testingLibraryCypressVersion
-} from '../../utils/versions';
+import { ionicReactRouterVersion } from '../../utils/versions';
 import init from '../init/schematic';
+import { configureCypressForIonic } from './lib/cypress';
+import { addIonicFiles, deleteUnusedFiles } from './lib/files';
+import { configureJestForIonic } from './lib/jest';
+import { updateWorkspaceForIonic } from './lib/update-workspace';
 import { ApplicationSchematicSchema } from './schema';
 
 const projectType = ProjectType.Application;
 
-interface NormalizedSchema extends ApplicationSchematicSchema {
+export interface NormalizedSchema extends ApplicationSchematicSchema {
   projectName: string;
   projectDirectory: string;
   projectRoot: string;
@@ -111,232 +86,17 @@ function generateNrwlReactApplication(options: ApplicationSchematicSchema) {
   });
 }
 
-function addFiles(options: NormalizedSchema): Rule {
-  return mergeWith(
-    apply(url(`./files/blank`), [
-      applyTemplates({
-        ...options,
-        ...names(options.name),
-        offsetFromRoot: offsetFromRoot(options.projectRoot)
-      }),
-      options.styledModule
-        ? filter(file => !file.endsWith(`.${options.style}`))
-        : noop(),
-      move(options.projectRoot),
-      options.js ? toJS() : noop()
-    ]),
-    MergeStrategy.Overwrite
-  );
-}
-
-function executeJestProjectSchematic(options: NormalizedSchema): Rule {
-  return externalSchematic('@nrwl/jest', 'jest-project', {
-    project: options.projectName,
-    supportTsx: true,
-    skipSerializers: true,
-    setupFile: 'web-components'
-  });
-}
-
-function updateSetupFilesJestConfig(options: NormalizedSchema) {
-  return (host: Tree) => {
-    const workspaceConfig = readWorkspace(host);
-    const configPath =
-      workspaceConfig.projects[options.projectName].architect.test.options
-        .jestConfig;
-    const contents = host.read(configPath).toString();
-
-    const sourceFile = ts.createSourceFile(
-      configPath,
-      contents,
-      ts.ScriptTarget.Latest
-    );
-
-    const changes: Change[] = [];
-    const sourceNodes = getSourceNodes(sourceFile);
-    const lastNode = sourceNodes[sourceNodes.length - 3];
-    changes.push(
-      new InsertChange(
-        configPath,
-        lastNode.getFullStart(),
-        `,\nmoduleNameMapper: {
-          '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
-            '<rootDir>/src/app/__mocks__/fileMock.js'
-        },
-        modulePathIgnorePatterns: ['<rootDir>/.*/__mocks__']\r`
-      )
-    );
-
-    insert(host, configPath, changes);
-  };
-}
-
-function addJestFiles(options: NormalizedSchema): Rule {
-  return mergeWith(
-    apply(url(`./files/jest`), [
-      applyTemplates({
-        ...options,
-        ...names(options.name),
-        offsetFromRoot: offsetFromRoot(options.projectRoot)
-      }),
-      move(options.projectRoot)
-    ]),
-    MergeStrategy.Overwrite
-  );
-}
-
-function configureJestForIonic(options: NormalizedSchema): Rule {
-  if (options.unitTestRunner === 'jest') {
-    return chain([
-      executeJestProjectSchematic(options),
-      updateSetupFilesJestConfig(options),
-      addJestFiles(options)
-    ]);
-  } else {
-    return noop();
-  }
-}
-
-function addCypressDependencies(): Rule {
-  return addDepsToPackageJson(
-    {},
-    {
-      '@testing-library/cypress': testingLibraryCypressVersion
-    }
-  );
-}
-
-function addCypressTestingLibraryTsconfigType(options: NormalizedSchema) {
-  return updateJsonInTree(options.e2eRoot + '/tsconfig.json', json => {
-    json.compilerOptions.types.push('@types/testing-library__cypress');
-    return json;
-  });
-}
-
-function importCypressTestingLibraryCommands(options: NormalizedSchema) {
-  return (tree: Tree) => {
-    const fileName = `${options.e2eRoot}/src/support/index.${
-      options.js ? 'js' : 'ts'
-    }`;
-
-    const content = tree.read(fileName);
-    let strContent = '';
-    if (content) {
-      strContent = content.toString();
-    }
-
-    const appendIndex = strContent.indexOf("import './commands';");
-    const contentToAppend = "import '@testing-library/cypress/add-commands';\n";
-    const updatedContent =
-      strContent.slice(0, appendIndex) +
-      contentToAppend +
-      strContent.slice(appendIndex);
-
-    tree.overwrite(fileName, updatedContent);
-    return tree;
-  };
-}
-
-function configureAppPageObjectForIonic(options: NormalizedSchema) {
-  return (tree: Tree) => {
-    const fileName = `${options.e2eRoot}/src/support/app.po.${
-      options.js ? 'js' : 'ts'
-    }`;
-
-    const content = tree.read(fileName);
-    let strContent = '';
-    if (content) {
-      strContent = content.toString();
-    }
-    const updatedContent = strContent.replace(
-      "cy.get('h1')",
-      "cy.get('.container')"
-    );
-
-    tree.overwrite(fileName, updatedContent);
-    return tree;
-  };
-}
-
-function configureAppTestForIonic(options: NormalizedSchema) {
-  return (tree: Tree) => {
-    const fileName = `${options.e2eRoot}/src/integration/app.spec.${
-      options.js ? 'js' : 'ts'
-    }`;
-
-    const content = tree.read(fileName);
-    let strContent = '';
-    if (content) {
-      strContent = content.toString();
-    }
-    const updatedContent = strContent.replace(
-      `Welcome to ${options.projectName}!`,
-      'Start with Ionic'
-    );
-
-    tree.overwrite(fileName, updatedContent);
-    return tree;
-  };
-}
-
-function configureCypressForIonic(options: NormalizedSchema): Rule {
-  if (options.e2eTestRunner === 'cypress') {
-    return chain([
-      addCypressDependencies(),
-      addCypressTestingLibraryTsconfigType(options),
-      importCypressTestingLibraryCommands(options),
-      configureAppPageObjectForIonic(options),
-      configureAppTestForIonic(options)
-    ]);
-  } else {
-    return noop();
-  }
-}
-
-function deleteUnusedFiles(options: NormalizedSchema): Rule {
-  return (tree: Tree) => {
-    tree.delete(options.projectRoot + '/src/favicon.ico');
-
-    if (!options.styledModule) {
-      tree.delete(
-        options.projectRoot + `/src/app/${options.appFileName}.` + options.style
-      );
-    }
-
-    return tree;
-  };
-}
-
-function updateWorkspace(options: NormalizedSchema): Rule {
-  return updateWorkspaceInTree(json => {
-    const architect = json.projects[options.projectName].architect;
-
-    const assets: string[] = architect.build.options.assets.filter(
-      (asset: string) => asset != options.projectRoot + '/src/favicon.ico'
-    );
-    assets.push(options.projectRoot + '/src/manifest.json');
-    architect.build.options.assets = assets;
-
-    architect.build.options.webpackConfig =
-      '@nxtend/ionic-react/plugins/webpack';
-
-    json.projects[options.projectName].architect = architect;
-
-    return json;
-  });
-}
-
 export default function(options: ApplicationSchematicSchema): Rule {
   const normalizedOptions = normalizeOptions(options);
   return chain([
     init(),
     addDependencies(),
     generateNrwlReactApplication(options),
-    addFiles(normalizedOptions),
+    addIonicFiles(normalizedOptions),
     configureJestForIonic(normalizedOptions),
     configureCypressForIonic(normalizedOptions),
     deleteUnusedFiles(normalizedOptions),
-    updateWorkspace(normalizedOptions),
+    updateWorkspaceForIonic(normalizedOptions),
     formatFiles()
   ]);
 }


### PR DESCRIPTION
# Description

The application schematic was getting rather large, so breaking it down into smaller files was much easier to reason about, and could make it easier to unit test these functions in the future.

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated
- [ ] e2e tests have been added or updated
- [ ] Changelog has been updated if necessary
- [x] `yarn affected:build` does not throw any warnings or errors
- [x] `yarn affected:lint` does not throw any warnings or errors
- [x] `yarn affected:test` does not throw any warnings or errors
- [ ] `yarn affected:e2e` does not throw any warnings or errors

# Issue

Resolves #97 
