### PR TITLE
fix(ionic-react): honor `unitTestRunner` flag

### DIFF
--- a/libs/ionic-react/CHANGELOG.md
+++ b/libs/ionic-react/CHANGELOG.md
@@ -9,6 +9,7 @@
 - upgrade `@testing-library/jest-dom` to 5.5.0
 - upgrade `@testing-library/cypress` to 6.0.0
 - upgrade `@testing-library/user-event` to 10.0.1
+- honor `unitTestRunner` flag
 
 # 1.0.2
 

--- a/libs/ionic-react/src/schematics/application/lib/files.ts
+++ b/libs/ionic-react/src/schematics/application/lib/files.ts
@@ -25,6 +25,9 @@ export function addIonicFiles(options: NormalizedSchema): Rule {
       options.styledModule
         ? filter(file => !file.endsWith(`.${options.style}`))
         : noop(),
+      options.unitTestRunner === 'none'
+        ? filter(file => !file.endsWith('.spec.tsx'))
+        : noop(),
       move(options.projectRoot),
       options.js ? toJS() : noop()
     ]),

--- a/libs/ionic-react/src/schematics/application/schematic.spec.ts
+++ b/libs/ionic-react/src/schematics/application/schematic.spec.ts
@@ -258,6 +258,18 @@ describe('application', () => {
         tree.exists(`${projectRoot}/src/test-setup.ts.template`)
       ).toBeFalsy();
     });
+
+    it('should not generate test files', async () => {
+      const tree = await testRunner
+        .runSchematicAsync(
+          'application',
+          { ...options, unitTestRunner: 'none' },
+          appTree
+        )
+        .toPromise();
+
+      expect(tree.exists(`${projectRoot}/src/app/app.spec.tsx`)).toBeFalsy();
+    });
   });
 
   describe('--e2eTestRunner', () => {


### PR DESCRIPTION
# Description

This plugin generated Jest unit test files even if a user passed `--unitTestRunner none`. This change filters out all test files when adding them to a generated application.

# PR Checklist

- [ ] Migrations have been added if necessary
- [x] Unit tests have been added or updated
- [ ] e2e tests have been added or updated
- [x] Changelog has been updated if necessary
- [x] `yarn affected:build` does not throw any warnings or errors
- [x] `yarn affected:lint` does not throw any warnings or errors
- [x] `yarn affected:test` does not throw any warnings or errors
- [ ] `yarn affected:e2e` does not throw any warnings or errors

# Issue

Resolves #96 
