### PR TITLE
chore(core): use Node 12 for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
   affected-build:
     executor:
       name: node/default
+      tag: '12'
     steps:
       - checkout
       - node/with-cache:
@@ -32,6 +33,7 @@ jobs:
   affected-lint:
     executor:
       name: node/default
+      tag: '12'
     steps:
       - checkout
       - node/with-cache:
@@ -43,6 +45,7 @@ jobs:
   affected-test:
     executor:
       name: node/default
+      tag: '12'
     steps:
       - checkout
       - node/with-cache:
@@ -54,6 +57,7 @@ jobs:
   affected-e2e:
     executor:
       name: node/default
+      tag: '12'
     steps:
       - checkout
       - node/with-cache:


### PR DESCRIPTION
Node 14 was released and is the default version that the CircleCI orb uses, so now I am defaulting to the latest LTS (12).

# Description

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated
- [ ] e2e tests have been added or updated
- [ ] Changelog has been updated if necessary
- [ ] `yarn affected:build` does not throw any warnings or errors
- [ ] `yarn affected:lint` does not throw any warnings or errors
- [ ] `yarn affected:test` does not throw any warnings or errors
- [ ] `yarn affected:e2e` does not throw any warnings or errors

# Issue

Resolves #
