### PR TITLE
feat(ionic-react): support disabling Ionic sanitizer

### DIFF
--- a/apps/ionic-react-e2e/tests/application.test.ts
+++ b/apps/ionic-react-e2e/tests/application.test.ts
@@ -3,7 +3,7 @@ import {
   ensureNxProject,
   readJson,
   runNxCommandAsync,
-  uniq
+  uniq,
 } from '@nrwl/nx-plugin/testing';
 
 describe('application e2e', () => {
@@ -52,7 +52,7 @@ describe('application e2e', () => {
     ).toThrow();
   }
 
-  it('should generate application', async done => {
+  it('should generate application', async (done) => {
     const plugin = uniq('ionic-react');
     ensureNxProject('@nxtend/ionic-react', 'dist/libs/ionic-react');
     await runNxCommandAsync(
@@ -66,7 +66,7 @@ describe('application e2e', () => {
     done();
   }, 120000);
 
-  it('should generate JavaScript files', async done => {
+  it('should generate JavaScript files', async (done) => {
     const plugin = uniq('ionic-react');
     ensureNxProject('@nxtend/ionic-react', 'dist/libs/ionic-react');
     await runNxCommandAsync(
@@ -89,7 +89,7 @@ describe('application e2e', () => {
     done();
   }, 120000);
 
-  it('should generate pascal case file names', async done => {
+  it('should generate pascal case file names', async (done) => {
     const plugin = uniq('ionic-react');
     ensureNxProject('@nxtend/ionic-react', 'dist/libs/ionic-react');
     await runNxCommandAsync(
@@ -114,7 +114,7 @@ describe('application e2e', () => {
   }, 120000);
 
   describe('--style', () => {
-    it('should generate application with scss style', async done => {
+    it('should generate application with scss style', async (done) => {
       const plugin = uniq('ionic-react');
       const style = 'scss';
       ensureNxProject('@nxtend/ionic-react', 'dist/libs/ionic-react');
@@ -129,7 +129,7 @@ describe('application e2e', () => {
       done();
     }, 120000);
 
-    it('should generate application with styled-components style', async done => {
+    it('should generate application with styled-components style', async (done) => {
       const plugin = uniq('ionic-react');
       const style = 'styled-components';
       ensureNxProject('@nxtend/ionic-react', 'dist/libs/ionic-react');
@@ -146,7 +146,7 @@ describe('application e2e', () => {
   });
 
   describe('--directory', () => {
-    it('should create src in the specified directory', async done => {
+    it('should create src in the specified directory', async (done) => {
       const plugin = uniq('ionic-react');
       ensureNxProject('@nxtend/ionic-react', 'dist/libs/ionic-react');
       await runNxCommandAsync(
@@ -162,7 +162,7 @@ describe('application e2e', () => {
   });
 
   describe('--tags', () => {
-    it('should add tags to nx.json', async done => {
+    it('should add tags to nx.json', async (done) => {
       const plugin = uniq('ionic-react');
       ensureNxProject('@nxtend/ionic-react', 'dist/libs/ionic-react');
       await runNxCommandAsync(
@@ -191,5 +191,22 @@ describe('application e2e', () => {
         checkFilesExist(`apps/${plugin}/jest.config.js.template`)
       ).toThrow();
     }, 120000);
+  });
+
+  describe('--disableSanitizer', () => {
+    describe('true', () => {
+      it('should add disable the Ionic sanitizer', async () => {
+        const plugin = uniq('ionic-react');
+        ensureNxProject('@nxtend/ionic-react', 'dist/libs/ionic-react');
+        await runNxCommandAsync(
+          `generate @nxtend/ionic-react:app ${plugin} --disableSanitizer`
+        );
+
+        const result = await runNxCommandAsync(
+          `build ${plugin} --maxWorkers=2`
+        );
+        expect(result.stdout).toContain('Built at');
+      }, 120000);
+    });
   });
 });

--- a/libs/ionic-react/CHANGELOG.md
+++ b/libs/ionic-react/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Features
 
 - upgrade Ionic to 5.1.0
+- add `--disableSanitizer` flag to application schematic to disable the [Ionic sanitizer](https://ionicframework.com/docs/techniques/security#sanitizing-user-input)
 
 # 2.1.0
 

--- a/libs/ionic-react/src/schematics/application/files/blank/src/app/__appFileName__.tsx.template
+++ b/libs/ionic-react/src/schematics/application/files/blank/src/app/__appFileName__.tsx.template
@@ -1,4 +1,4 @@
-import { IonApp, IonRouterOutlet } from '@ionic/react';
+import { IonApp, IonRouterOutlet<% if (disableSanitizer) { %>, setupConfig<% } %> } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';<% 
 if (styledModule) { %>
 import { createGlobalStyle } from '<%= styledModule %>';<% } %>
@@ -253,8 +253,12 @@ import '@ionic/react/css/display.css';
     }
   }
 `;<% } else { %>/* Theme variables */
-import './theme/variables.<%= style %>';<% } %>
-<% if (classComponent) {
+import './theme/variables.<%= style %>';<% } %><%
+if (disableSanitizer) { %>
+
+setupConfig({
+  sanitizerEnabled: false
+});<% } %><% if (classComponent) {
   var innerJsx = `
         <IonApp>${styledModule ? `
           <StyledApp />` : ''}

--- a/libs/ionic-react/src/schematics/application/schema.d.ts
+++ b/libs/ionic-react/src/schematics/application/schema.d.ts
@@ -13,4 +13,5 @@ export interface ApplicationSchematicSchema {
   classComponent?: boolean;
   skipWorkspaceJson?: boolean;
   js?: boolean;
+  disableSanitizer: boolean;
 }

--- a/libs/ionic-react/src/schematics/application/schema.json
+++ b/libs/ionic-react/src/schematics/application/schema.json
@@ -114,6 +114,11 @@
       "type": "boolean",
       "description": "Generate JavaScript files rather than TypeScript files",
       "default": false
+    },
+    "disableSanitizer": {
+      "type": "boolean",
+      "description": "Disable Ionic sanitizer",
+      "default": false
     }
   },
   "required": []

--- a/libs/ionic-react/src/schematics/application/schematic.spec.ts
+++ b/libs/ionic-react/src/schematics/application/schematic.spec.ts
@@ -13,7 +13,8 @@ describe('application', () => {
     skipFormat: false,
     unitTestRunner: 'jest',
     e2eTestRunner: 'cypress',
-    linter: Linter.EsLint
+    linter: Linter.EsLint,
+    disableSanitizer: false,
   };
 
   const projectRoot = `apps/${options.name}`;
@@ -343,6 +344,26 @@ describe('application', () => {
         .toPromise();
 
       expect(tree.exists(`${projectRoot}-e2e/tsconfig.json`)).toBeFalsy();
+    });
+  });
+
+  describe('--disableSanitizer', () => {
+    describe('true', () => {
+      it('should add disable the Ionic sanitizer', async () => {
+        const tree = await testRunner
+          .runSchematicAsync(
+            'application',
+            { ...options, disableSanitizer: true },
+            appTree
+          )
+          .toPromise();
+        const appTsx = tree.readContent(`${projectRoot}/src/app/app.tsx`);
+
+        expect(appTsx).toContain(
+          `import { IonApp, IonRouterOutlet, setupConfig } from '@ionic/react';`
+        );
+        expect(appTsx).toContain(`sanitizerEnabled: false`);
+      });
     });
   });
 });


### PR DESCRIPTION
# Description

In Ionic 5.1.0, the Ionic team added a feature that allows users to eject from the Ionic sanitizer application-wide. This PR adds a flag to the application schematic to implement this new feature.

https://github.com/ionic-team/ionic/pull/20457

# PR Checklist

- [x] Migrations have been added if necessary
- [x] Unit tests have been added or updated if necessary
- [x] e2e tests have been added or updated if necessary
- [x] Changelog has been updated if necessary

# Issue

Resolves #122 
